### PR TITLE
Improve exceptions

### DIFF
--- a/datapackage/datapackage.py
+++ b/datapackage/datapackage.py
@@ -192,7 +192,7 @@ class DataPackage(object):
 
         Raises:
             ValidationError: If the Data Package is invalid.
-            DataPackageException: If there were some error writing the package.
+            DataPackageException: If there was some error writing the package.
         '''
         self.validate()
 


### PR DESCRIPTION
Fixes #30 

I've changed my mind about how to handle exceptions. I think we should wrap the exceptions in most cases. This way, the user can do something like:

```python
import datapackage

try:
    dp = datapackage.DataPackage('datapackage.json')
except datapackage.exceptions.RegistryError:
    # handles registry errors
except datapackage.exceptions.SchemaError:
    # handles schema errors
except datapackage.exceptions.DataPackageException:
    # handles any other error
```

Or, if she doesn't care on the type of exception, she could just catch `datapackage.exceptions.DataPackageException`. The only exceptions that don't inherit from `DataPackageException` are the ones related to the data. For example:

```python
try:
    dp.resources[0].data
except IOError:
    # when there were errors loading the data
except ValueError:
    # when there were errors parsing the data
```

These exceptions are consistent with the rest of Python ecosystem when loading/parsing data, so I think they're OK.