### PR TITLE
Extract tempfile creation to fixtures in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+ # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import pytest
+import tempfile
+
+
+@pytest.yield_fixture()
+def tmpfile():
+    with tempfile.NamedTemporaryFile() as f:
+        yield f
+
+
+@pytest.yield_fixture()
+def txt_tmpfile():
+    with tempfile.NamedTemporaryFile(suffix='.txt') as f:
+        yield f
+
+
+@pytest.yield_fixture()
+def csv_tmpfile():
+    with tempfile.NamedTemporaryFile(suffix='.csv') as f:
+        yield f

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -692,21 +692,14 @@ class TestSafeDataPackage(object):
         assert not dp.safe()
 
 
-@pytest.yield_fixture
-def tmpfile():
-    with tempfile.NamedTemporaryFile() as f:
-        yield f
-
-
-@pytest.yield_fixture
-def datapackage_zip():
-    with tempfile.NamedTemporaryFile() as f:
-        metadata = {
-            'name': 'proverbs',
-            'resources': [
-                {'path': test_helpers.fixture_path('foo.txt')},
-            ]
-        }
-        dp = datapackage.DataPackage(metadata)
-        dp.save(f)
-        yield f
+@pytest.fixture
+def datapackage_zip(tmpfile):
+    metadata = {
+        'name': 'proverbs',
+        'resources': [
+            {'path': test_helpers.fixture_path('foo.txt')},
+        ]
+    }
+    dp = datapackage.DataPackage(metadata)
+    dp.save(tmpfile)
+    return tmpfile

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
-import tempfile
 import pytest
 import httpretty
 import tests.test_helpers as test_helpers
@@ -346,17 +345,16 @@ class TestResource(object):
 
         assert [row for row in resource.iter()] == [51]
 
-    def test_iterator_with_local_data(self):
+    def test_iterator_with_local_data(self, txt_tmpfile):
         contents = (
             'first line\n'
             'second line\n'
         )
 
-        with tempfile.NamedTemporaryFile(suffix='.txt') as tmpfile:
-            tmpfile.write(contents.encode('utf-8'))
-            tmpfile.flush()
-            resource = datapackage.Resource.load({'path': tmpfile.name})
-            data = [row for row in resource.iter()]
+        txt_tmpfile.write(contents.encode('utf-8'))
+        txt_tmpfile.flush()
+        resource = datapackage.Resource.load({'path': txt_tmpfile.name})
+        data = [row for row in resource.iter()]
 
         assert data == [b'first line\n', b'second line\n']
 
@@ -475,18 +473,17 @@ class TestTabularResource(object):
 
         assert [row for row in resource.iter()] == data
 
-    def test_iterator_with_local_data(self):
+    def test_iterator_with_local_data(self, csv_tmpfile):
         csv_contents = (
             'country,value\n'
             'China,中国\n'
             'Brazil,Brasil\n'
         ).encode('utf-8')
+        csv_tmpfile.write(csv_contents)
+        csv_tmpfile.flush()
 
-        with tempfile.NamedTemporaryFile(suffix='.csv') as tmpfile:
-            tmpfile.write(csv_contents)
-            tmpfile.flush()
-            resource = TabularResource({'path': tmpfile.name})
-            data = [row for row in resource.iter()]
+        resource = TabularResource({'path': csv_tmpfile.name})
+        data = [row for row in resource.iter()]
 
         assert data == [
             {'country': 'China', 'value': '中国'},
@@ -519,13 +516,12 @@ class TestTabularResource(object):
         with pytest.raises(ValueError):
             [row for row in resource.iter()]
 
-    def test_iterator_with_local_non_tabular_data(self):
-        with tempfile.NamedTemporaryFile(suffix='.txt') as tmpfile:
-            tmpfile.write('foo'.encode('utf-8'))
-            tmpfile.flush()
-            resource = TabularResource({'path': tmpfile.name})
-            with pytest.raises(ValueError):
-                [row for row in resource.iter()]
+    def test_iterator_with_local_non_tabular_data(self, txt_tmpfile):
+        txt_tmpfile.write('foo'.encode('utf-8'))
+        txt_tmpfile.flush()
+        resource = TabularResource({'path': txt_tmpfile.name})
+        with pytest.raises(ValueError):
+            [row for row in resource.iter()]
 
     @httpretty.activate
     def test_iterator_with_remote_non_tabular_data(self):


### PR DESCRIPTION
@pwalsh This encapsulates tempfile creation, so if we have some issue with py3 we just need to fix in one place.