### PR TITLE
[#48] Adds Registry.REGISTRY_DEFAULT_URL pointing to the official registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ with open('datapackage.json', 'w') as f:
 # {"name": "my_sleep_duration", "resources": [{"data": [7, 8, 5, 6, 9, 7, 8], "name": "data"}]}
 ```
 
+### Using a schema that's not in the local cache
+
+```python
+import datapackage
+import datapackage.registry
+
+# This constant points to the official registry URL
+# You can use any URL or path that points to a registry CSV
+registry_url = datapackage.registry.Registry.DEFAULT_REGISTRY_URL
+registry = datapackage.registry.Registry(registry_url)
+
+metadata = {}  # The datapackage.json file
+schema = registry.get('tabular')  # Change to your schema ID
+
+dp = datapackage.DataPackage(metadata, schema)
+```
+
 ## Developer notes
 
 These notes are intended to help people that want to contribute to this

--- a/datapackage/registry.py
+++ b/datapackage/registry.py
@@ -23,6 +23,7 @@ class Registry(object):
         RegistryError: If there was some problem opening the registry file or
             its format was incorrect.
     '''
+    DEFAULT_REGISTRY_URL = 'http://schemas.datapackages.org/registry.csv'
     DEFAULT_REGISTRY_PATH = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         'schemas',

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -83,6 +83,10 @@ class TestRegistry(object):
         with pytest.raises(RegistryError):
             datapackage.registry.Registry(registry_path)
 
+    def test_it_has_default_registry_url_const(self):
+        url = 'http://schemas.datapackages.org/registry.csv'
+        assert datapackage.registry.Registry.DEFAULT_REGISTRY_URL == url
+
     def test_available_profiles_returns_empty_dict_when_registry_is_empty(self):
         registry_path = self.EMPTY_REGISTRY_PATH
         registry = datapackage.registry.Registry(registry_path)


### PR DESCRIPTION
This allows users to use the latest schemas from the official registry without
having to hardcode its URL in their code. Currently it points to
'http://schemas.datapackages.org/registry.csv'.

Fixes #48 

cc @pwalsh 